### PR TITLE
Add CLI utility to sync Kindle highlights to Obsidian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+/.pytest_cache/
+/.venv/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,100 @@
-# Obsidian-Kindle-Highlgights
-A program that keeps track of my kindle book highlights and adds them to an Obsidian Vault
+# Obsidian Kindle Highlights Sync
+
+A small utility for ingesting Kindle annotations and exporting them into Markdown files that can be stored inside an [Obsidian](https://obsidian.md/) vault. Highlights are normalised, deduplicated and grouped per book to keep your notes tidy.
+
+## Features
+
+- Parse highlights from the standard Kindle `My Clippings.txt` file and Kindle Export CSV downloads.
+- Normalise entries into a structured model that includes title, author, location, highlight text and optional notes.
+- Write Markdown files per book with YAML-style front matter, safe filenames and configurable heading templates.
+- Merge new highlights by tracking stored highlight hashes to avoid duplicates.
+- Dry-run mode to preview changes and a lightweight test suite to verify parsers.
+
+## Requirements
+
+- Python 3.10 or newer.
+
+## Installation
+
+Clone the repository and install the project in editable mode (optional but recommended if you plan to iterate):
+
+```bash
+pip install -e .
+```
+
+> The project does not require third-party dependencies; installing in editable mode simply makes the `src` directory importable.
+
+## Usage
+
+The entry point lives in `src/sync_highlights.py` and can be executed with Python:
+
+```bash
+python -m sync_highlights --clippings "~/Documents/My Clippings.txt" --vault "/path/to/Obsidian" --dry-run
+```
+
+### Command line flags
+
+| Flag | Description |
+| --- | --- |
+| `--config` | Path to a JSON configuration file. CLI flags override values from the file. |
+| `--clippings` | Path to the Kindle `My Clippings.txt` export. |
+| `--csv` | Optional Kindle Export CSV file. |
+| `--vault` | Root folder of the target Obsidian vault. |
+| `--subdir` | Subdirectory under the vault root for storing highlight files (default: `Kindle Highlights`). |
+| `--heading-template` | Template for highlight headings. Available placeholders: `{title}`, `{author}`, `{location}`. |
+| `--dry-run` | Parse highlights and report changes without writing files. |
+| `--list` | Alias for `--dry-run` that only lists the results. |
+
+### Configuration file
+
+Instead of passing paths via CLI you can keep them in a JSON file. Example `config.json`:
+
+```json
+{
+  "clippings_path": "~/Documents/My Clippings.txt",
+  "kindle_export_csv": "~/Downloads/kindle.csv",
+  "vault_root": "/Users/alex/Obsidian/My Vault",
+  "vault_subdir": "Kindle Highlights",
+  "highlight_heading_template": "Location {location}"
+}
+```
+
+Run the synchroniser with:
+
+```bash
+python -m sync_highlights --config config.json
+```
+
+### Markdown output
+
+Each book gets its own Markdown file (e.g. `Kindle Highlights/The_Example_Book.md`) with front matter containing the title, author and stored highlight hashes. Highlights are rendered as sections:
+
+```markdown
+### Location 120-122
+> The highlighted text
+
+**Note:** Optional note text
+<!-- highlight-id: 123abc... -->
+```
+
+The stored `highlight_ids` in front matter are used to avoid adding the same passage multiple times.
+
+### Dry-run and validation
+
+Use the dry-run flag to inspect what would be written:
+
+```bash
+python -m sync_highlights --config config.json --dry-run
+```
+
+Dry-run inspects existing Markdown files, reports how many new highlights would be added and leaves the file system untouched.
+
+## Tests
+
+Run the lightweight tests to confirm the parsers behave as expected:
+
+```bash
+python -m pytest
+```
+
+The tests exercise the My Clippings and Kindle CSV parsers using small synthetic samples.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "obsidian-kindle-highlights"
+version = "0.1.0"
+description = "Sync Kindle highlights into an Obsidian vault."
+requires-python = ">=3.10"
+dependencies = []
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = src

--- a/src/highlights/__init__.py
+++ b/src/highlights/__init__.py
@@ -1,0 +1,6 @@
+"""Utilities for syncing Kindle highlights into Markdown."""
+
+from .config import SyncConfig
+from .models import Highlight, BookHighlights
+
+__all__ = ["SyncConfig", "Highlight", "BookHighlights"]

--- a/src/highlights/config.py
+++ b/src/highlights/config.py
@@ -1,0 +1,45 @@
+"""Configuration helpers for the highlight synchroniser."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class SyncConfig:
+    """Holds configuration for syncing highlights."""
+
+    clippings_path: Optional[Path] = None
+    kindle_export_csv: Optional[Path] = None
+    vault_root: Path = Path("./vault")
+    vault_subdir: str = "Kindle Highlights"
+    dry_run: bool = False
+    highlight_heading_template: str = "Location {location}"
+
+    @classmethod
+    def from_mapping(cls, data: Dict[str, Any]) -> "SyncConfig":
+        kwargs: Dict[str, Any] = {}
+        if "clippings_path" in data and data["clippings_path"]:
+            kwargs["clippings_path"] = Path(data["clippings_path"])
+        if "kindle_export_csv" in data and data["kindle_export_csv"]:
+            kwargs["kindle_export_csv"] = Path(data["kindle_export_csv"])
+        if "vault_root" in data and data["vault_root"]:
+            kwargs["vault_root"] = Path(data["vault_root"])
+        if "vault_subdir" in data and data["vault_subdir"]:
+            kwargs["vault_subdir"] = str(data["vault_subdir"])
+        if "dry_run" in data:
+            kwargs["dry_run"] = bool(data["dry_run"])
+        if "highlight_heading_template" in data and data["highlight_heading_template"]:
+            kwargs["highlight_heading_template"] = str(data["highlight_heading_template"])
+        return cls(**kwargs)
+
+
+def load_config(path: Optional[Path]) -> Dict[str, Any]:
+    """Load a JSON configuration file if provided."""
+
+    if path is None:
+        return {}
+    with path.expanduser().resolve().open("r", encoding="utf-8") as handle:
+        return json.load(handle)

--- a/src/highlights/markdown.py
+++ b/src/highlights/markdown.py
@@ -1,0 +1,126 @@
+"""Markdown rendering for highlights."""
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from typing import List, Optional, Sequence
+
+from .models import Highlight
+
+SAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._\- ]+")
+
+
+def sanitise_filename(value: str) -> str:
+    """Return a filesystem-safe filename derived from ``value``."""
+
+    safe = SAFE_FILENAME_CHARS.sub(" ", value).strip()
+    safe = re.sub(r"\s+", " ", safe)
+    safe = safe.replace(" ", "_")
+    return safe or "untitled"
+
+
+def format_front_matter(metadata: dict) -> str:
+    lines: List[str] = ["---"]
+    for key, value in metadata.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"  - {item}")
+        elif value is None:
+            lines.append(f"{key}:")
+        else:
+            if isinstance(value, str):
+                safe_value = value.replace("\n", " ").replace('"', '\\"')
+                safe_value = f'"{safe_value}"'
+            else:
+                safe_value = str(value).replace("\n", " ")
+            lines.append(f"{key}: {safe_value}")
+    lines.append("---")
+    return "\n".join(lines) + "\n"
+
+
+def parse_front_matter(text: str) -> tuple[dict, str]:
+    if not text.startswith("---\n"):
+        return {}, text
+    end_index = text.find("\n---", 4)
+    if end_index == -1:
+        return {}, text
+    fm_text = text[4:end_index]
+    remainder = text[end_index + 4 :]
+    if remainder.startswith("\n"):
+        remainder = remainder[1:]
+
+    metadata: dict = {}
+    current_key: Optional[str] = None
+    for raw_line in fm_text.splitlines():
+        line = raw_line.rstrip()
+        if not line:
+            continue
+        if line.startswith("  - ") and current_key:
+            metadata.setdefault(current_key, []).append(line[4:].strip())
+            continue
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if not value:
+                metadata[key] = []
+                current_key = key
+            else:
+                if value.startswith('"') and value.endswith('"'):
+                    value = value[1:-1].replace('\\"', '"')
+                metadata[key] = value
+                current_key = None
+    return metadata, remainder
+
+
+def render_highlight(highlight: Highlight, heading_template: str = "Location {location}") -> str:
+    lines: List[str] = []
+    context = {
+        "title": highlight.book_title,
+        "author": highlight.author or "",
+        "location": highlight.location or "unknown",
+    }
+    try:
+        heading_value = heading_template.format(**context)
+    except (KeyError, ValueError):
+        heading_value = f"Location {context['location']}"
+    location_text = heading_value or f"Location {context['location']}"
+    lines.append(f"### {location_text}")
+    lines.append("")
+    if highlight.text:
+        quote = highlight.text.strip().replace("\n", "\n>")
+        lines.append(f"> {quote}")
+    else:
+        lines.append("> _No highlight text available._")
+    if highlight.note:
+        lines.append("")
+        lines.append(f"**Note:** {highlight.note.strip()}")
+    lines.append("")
+    lines.append(f"<!-- highlight-id: {highlight.highlight_id} -->")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_book_document(
+    title: str,
+    author: Optional[str],
+    highlights: Sequence[Highlight],
+    heading_template: str = "Location {location}",
+) -> str:
+    metadata = {
+        "title": title,
+        "author": author or "Unknown",
+        "updated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "highlight_ids": [h.highlight_id for h in highlights],
+    }
+    front_matter = format_front_matter(metadata)
+    heading_lines = [f"# {title}"]
+    if author:
+        heading_lines.append("")
+        heading_lines.append(f"_by {author}_")
+    heading_lines.append("")
+
+    body_parts = [render_highlight(highlight, heading_template=heading_template) for highlight in highlights]
+    body = "\n".join(body_parts)
+    return front_matter + "\n".join(heading_lines) + body + ("\n" if not body.endswith("\n") else "")

--- a/src/highlights/models.py
+++ b/src/highlights/models.py
@@ -1,0 +1,41 @@
+"""Data models for Kindle highlight synchronization."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from hashlib import sha1
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Highlight:
+    """Represents a Kindle highlight or note."""
+
+    book_title: str
+    author: Optional[str]
+    location: Optional[str]
+    text: str
+    note: Optional[str] = None
+    source: str = "unknown"
+    highlight_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        # Normalise values used for hashing so that id generation is stable.
+        components = [
+            (self.book_title or "").strip(),
+            (self.author or "").strip(),
+            (self.location or "").strip(),
+            (self.text or "").strip(),
+            (self.note or "").strip(),
+            (self.source or "").strip(),
+        ]
+        digest_input = "\u241f".join(components).encode("utf-8")
+        object.__setattr__(self, "highlight_id", sha1(digest_input).hexdigest())
+
+
+@dataclass
+class BookHighlights:
+    """Grouping of highlights for a single book."""
+
+    title: str
+    author: Optional[str]
+    highlights: list[Highlight]

--- a/src/highlights/parsers.py
+++ b/src/highlights/parsers.py
@@ -1,0 +1,170 @@
+"""Parsers that ingest Kindle highlight exports."""
+from __future__ import annotations
+
+import csv
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from .models import Highlight
+
+
+class HighlightParser:
+    """Base class for highlight parsers."""
+
+    def parse(self, path: Path) -> Iterable[Highlight]:
+        raise NotImplementedError
+
+
+class MyClippingsParser(HighlightParser):
+    """Parses the legacy `My Clippings.txt` Kindle export."""
+
+    SEPARATOR = "=========="
+    META_PATTERN = re.compile(
+        r"^-\s*Your\s+(?P<entry_type>Highlight|Note)\s+on\s+"  # entry type
+        r"(?:(?:Location|Page)\s+(?P<location>[\d\-]+))?.*"  # location (optional)
+    )
+
+    HEADER_PATTERN = re.compile(
+        r"^(?P<title>.+?)(?:\s*\((?P<author>[^)]*)\))?$"
+    )
+
+    @staticmethod
+    def _location_key(location: Optional[str]) -> Optional[str]:
+        if not location:
+            return None
+        match = re.match(r"(\d+)", location)
+        if match:
+            return match.group(1)
+        return location
+
+    def parse(self, path: Path) -> Iterable[Highlight]:
+        text = path.expanduser().resolve().read_text(encoding="utf-8-sig")
+        raw_entries = [segment.strip() for segment in text.split(self.SEPARATOR)]
+
+        entries: List[Dict[str, Optional[str]]] = []
+        last_highlight_index: Dict[Tuple[str, Optional[str], Optional[str]], int] = {}
+
+        for raw in raw_entries:
+            if not raw:
+                continue
+            lines = [line.rstrip("\ufeff").strip() for line in raw.splitlines() if line.strip()]
+            if len(lines) < 2:
+                continue
+            header_match = self.HEADER_PATTERN.match(lines[0])
+            if not header_match:
+                continue
+            title = header_match.group("title").strip()
+            author = header_match.group("author")
+            author = author.strip() if author else None
+
+            meta_match = self.META_PATTERN.match(lines[1])
+            if not meta_match:
+                continue
+            entry_type = meta_match.group("entry_type")
+            location = meta_match.group("location")
+
+            body = "\n".join(lines[2:]).strip()
+            key = (title, author, self._location_key(location))
+
+            if entry_type == "Note":
+                if not body:
+                    continue
+                index = last_highlight_index.get(key)
+                if index is not None:
+                    entries[index]["note"] = body
+                else:
+                    entries.append(
+                        {
+                            "book_title": title,
+                            "author": author,
+                            "location": location,
+                            "text": "",
+                            "note": body,
+                            "source": "my_clippings",
+                        }
+                    )
+                continue
+
+            entry = {
+                "book_title": title,
+                "author": author,
+                "location": location,
+                "text": body,
+                "note": None,
+                "source": "my_clippings",
+            }
+            entries.append(entry)
+            last_highlight_index[key] = len(entries) - 1
+
+        highlights: List[Highlight] = []
+        for entry in entries:
+            if not (entry["text"] or entry["note"]):
+                continue
+            highlights.append(
+                Highlight(
+                    book_title=entry["book_title"] or "Unknown",
+                    author=entry["author"],
+                    location=entry["location"],
+                    text=entry["text"] or "",
+                    note=entry["note"],
+                    source=str(entry["source"] or "my_clippings"),
+                )
+            )
+
+        return highlights
+
+
+class KindleCsvParser(HighlightParser):
+    """Parses Kindle Export CSV files."""
+
+    def parse(self, path: Path) -> Iterable[Highlight]:
+        highlights: List[Highlight] = []
+        with path.expanduser().resolve().open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.DictReader(handle)
+            for row in reader:
+                title = (row.get("title") or row.get("Book Title") or row.get("book_title") or "").strip()
+                author = (row.get("author") or row.get("Authors") or row.get("authors") or None)
+                author = author.strip() if author else None
+                location = (row.get("Location") or row.get("location") or row.get("annotation_location") or None)
+                location = location.strip() if isinstance(location, str) else location
+                text = (row.get("Highlight") or row.get("highlight") or row.get("annotation") or "").strip()
+                note = row.get("Note") or row.get("note")
+                if isinstance(note, str):
+                    note = note.strip() or None
+
+                if not any([text, note]):
+                    continue
+
+                highlights.append(
+                    Highlight(
+                        book_title=title,
+                        author=author,
+                        location=location,
+                        text=text,
+                        note=note,
+                        source="kindle_csv",
+                    )
+                )
+        return highlights
+
+
+def group_by_book(highlights: Iterable[Highlight]) -> Iterable[Tuple[str, Optional[str], List[Highlight]]]:
+    grouped: Dict[Tuple[str, Optional[str]], List[Highlight]] = defaultdict(list)
+    for highlight in highlights:
+        grouped[(highlight.book_title, highlight.author)].append(highlight)
+
+    for (title, author), items in sorted(
+        grouped.items(), key=lambda item: (item[0][0].lower(), item[0][1] or "")
+    ):
+        # Sort by numeric component of location if available
+        def location_key(value: Highlight) -> Tuple[int, str]:
+            if value.location:
+                match = re.search(r"\d+", value.location)
+                if match:
+                    return int(match.group()), value.location
+            return (1 << 30, value.location or "")
+
+        items.sort(key=location_key)
+        yield title, author, items

--- a/src/highlights/storage.py
+++ b/src/highlights/storage.py
@@ -1,0 +1,85 @@
+"""Helpers for persisting highlights to Markdown files."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, Sequence, Set, Tuple
+
+from .markdown import format_front_matter, parse_front_matter, render_highlight, sanitise_filename
+from .models import Highlight
+
+
+class BookFile:
+    """Represents an on-disk Markdown file for a book's highlights."""
+
+    def __init__(self, path: Path, title: str, author: Optional[str]) -> None:
+        self.path = path
+        self.title = title
+        self.author = author
+
+    def read(self) -> tuple[dict, str]:
+        if not self.path.exists():
+            return {}, ""
+        text = self.path.read_text(encoding="utf-8")
+        return parse_front_matter(text)
+
+    def write(self, metadata: dict, body: str) -> None:
+        content = format_front_matter(metadata) + body
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(content, encoding="utf-8")
+
+
+def build_book_filename(vault_root: Path, subdir: str, title: str) -> Path:
+    safe_title = sanitise_filename(title)
+    relative = Path(subdir) / f"{safe_title}.md"
+    return vault_root / relative
+
+
+def merge_highlights(existing_ids: Set[str], highlights: Sequence[Highlight]) -> List[Highlight]:
+    return [h for h in highlights if h.highlight_id not in existing_ids]
+
+
+def append_highlights_to_file(
+    book_file: BookFile, highlights: Sequence[Highlight], heading_template: str = "Location {location}"
+) -> Tuple[int, int]:
+    metadata, existing_body = book_file.read()
+    existing_ids_list: List[str] = []
+    if metadata:
+        ids = metadata.get("highlight_ids")
+        if isinstance(ids, list):
+            existing_ids_list = [str(value) for value in ids]
+    existing_ids: Set[str] = set(existing_ids_list)
+
+    new_highlights = merge_highlights(existing_ids, highlights)
+    if not new_highlights:
+        return 0, len(existing_ids)
+
+    updated_ids = existing_ids_list + [h.highlight_id for h in new_highlights]
+    updated_ids = list(dict.fromkeys(updated_ids))
+
+    metadata = dict(metadata)
+    metadata.update(
+        {
+            "title": metadata.get("title") or book_file.title,
+            "author": metadata.get("author") or (book_file.author or "Unknown"),
+            "highlight_ids": updated_ids,
+            "updated": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        }
+    )
+
+    if not existing_body:
+        header_lines = [f"# {book_file.title}"]
+        if book_file.author:
+            header_lines.append("")
+            header_lines.append(f"_by {book_file.author}_")
+        header_lines.append("")
+        existing_body = "\n".join(header_lines)
+
+    body_parts = [existing_body.rstrip("\n"), ""]
+    for highlight in new_highlights:
+        body_parts.append(render_highlight(highlight, heading_template=heading_template))
+    body_parts.append("")
+    new_body = "\n".join(body_parts)
+
+    book_file.write(metadata, new_body)
+    return len(new_highlights), len(updated_ids)

--- a/src/sync_highlights.py
+++ b/src/sync_highlights.py
@@ -1,0 +1,130 @@
+"""Command line entry point for syncing Kindle highlights into an Obsidian vault."""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Iterable, List
+
+from highlights.config import SyncConfig, load_config
+from highlights.models import Highlight
+from highlights.parsers import KindleCsvParser, MyClippingsParser, group_by_book
+from highlights.storage import (
+    BookFile,
+    append_highlights_to_file,
+    build_book_filename,
+    merge_highlights,
+)
+
+
+def _parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, help="Path to JSON configuration file", default=None)
+    parser.add_argument("--clippings", type=Path, help="Path to 'My Clippings.txt'", default=None)
+    parser.add_argument("--csv", type=Path, help="Path to Kindle Export CSV file", default=None)
+    parser.add_argument("--vault", type=Path, help="Path to the root of the Obsidian vault", default=None)
+    parser.add_argument("--subdir", help="Subdirectory inside the vault for highlight files", default=None)
+    parser.add_argument(
+        "--heading-template",
+        help="Template for highlight headings (available keys: title, author, location)",
+        default=None,
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Run without writing files")
+    parser.add_argument(
+        "--list", action="store_true", dest="list_only", help="List parsed highlights without writing"
+    )
+    return parser.parse_args(argv)
+
+
+def _combine_config(args: argparse.Namespace) -> SyncConfig:
+    try:
+        file_config = load_config(args.config)
+    except FileNotFoundError as exc:  # pragma: no cover - user error
+        raise SystemExit(f"Configuration file not found: {args.config}") from exc
+    except OSError as exc:  # pragma: no cover - user error
+        raise SystemExit(f"Failed to read configuration file: {exc}") from exc
+    config = SyncConfig.from_mapping(file_config)
+
+    if args.clippings is not None:
+        config.clippings_path = args.clippings
+    if args.csv is not None:
+        config.kindle_export_csv = args.csv
+    if args.vault is not None:
+        config.vault_root = args.vault
+    if args.subdir is not None:
+        config.vault_subdir = args.subdir
+    if args.heading_template is not None:
+        config.highlight_heading_template = args.heading_template
+    if args.dry_run:
+        config.dry_run = True
+    return config
+
+
+def _collect_highlights(config: SyncConfig) -> List[Highlight]:
+    highlights: List[Highlight] = []
+    if config.clippings_path:
+        path = config.clippings_path.expanduser()
+        if path.exists():
+            parser = MyClippingsParser()
+            highlights.extend(parser.parse(path))
+        else:
+            print(f"Warning: {path} not found; skipping My Clippings source.")
+    if config.kindle_export_csv:
+        path = config.kindle_export_csv.expanduser()
+        if path.exists():
+            parser = KindleCsvParser()
+            highlights.extend(parser.parse(path))
+        else:
+            print(f"Warning: {path} not found; skipping Kindle CSV source.")
+    return highlights
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    config = _combine_config(args)
+
+    highlights = _collect_highlights(config)
+    if not highlights:
+        print("No highlights found in the provided sources.")
+        return 1
+
+    book_groups = list(group_by_book(highlights))
+    total_new = 0
+
+    if args.list_only or config.dry_run:
+        print(f"Found {len(highlights)} highlights across {len(book_groups)} books.")
+
+    for title, author, book_highlights in book_groups:
+        book_path = build_book_filename(config.vault_root, config.vault_subdir, title)
+        book_file = BookFile(book_path, title, author)
+
+        if args.list_only or config.dry_run:
+            metadata, _ = book_file.read()
+            existing_ids = set()
+            if metadata:
+                ids = metadata.get("highlight_ids")
+                if isinstance(ids, list):
+                    existing_ids = {str(value) for value in ids}
+            new_items = merge_highlights(existing_ids, book_highlights)
+            print(
+                f"[DRY-RUN] Would update {book_path} with {len(new_items)} new highlight(s) ("
+                f"{len(book_highlights)} parsed)."
+            )
+            continue
+
+        added, total = append_highlights_to_file(
+            book_file, book_highlights, heading_template=config.highlight_heading_template
+        )
+        total_new += added
+        print(f"Updated {book_path} (+{added} new / {total} total).")
+
+    if not (args.list_only or config.dry_run):
+        print(f"Sync complete: {total_new} new highlights added.")
+    else:
+        print("Dry-run complete; no files were written.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -1,0 +1,55 @@
+import csv
+from pathlib import Path
+
+from highlights.parsers import KindleCsvParser, MyClippingsParser
+
+
+MY_CLIPPINGS_SAMPLE = """The Example Book (Jane Doe)
+- Your Highlight on Location 120-122 | Added on Friday, 1 January 2021 10:00:00
+This is a highlight from the book.
+==========
+The Example Book (Jane Doe)
+- Your Note on Location 120 | Added on Friday, 1 January 2021 10:00:00
+This is an attached note.
+==========
+"""
+
+
+def test_my_clippings_parser_combines_notes(tmp_path: Path) -> None:
+    sample_path = tmp_path / "My Clippings.txt"
+    sample_path.write_text(MY_CLIPPINGS_SAMPLE, encoding="utf-8")
+
+    parser = MyClippingsParser()
+    highlights = list(parser.parse(sample_path))
+
+    assert len(highlights) == 1
+    highlight = highlights[0]
+    assert highlight.text.startswith("This is a highlight")
+    assert highlight.note == "This is an attached note."
+    assert highlight.location == "120-122"
+    assert highlight.highlight_id  # hash generated
+
+
+def test_kindle_csv_parser(tmp_path: Path) -> None:
+    sample_path = tmp_path / "kindle.csv"
+    with sample_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=["title", "author", "Highlight", "Note", "Location"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "title": "The Example Book",
+                "author": "Jane Doe",
+                "Highlight": "CSV highlight text",
+                "Note": "CSV note",
+                "Location": "200-201",
+            }
+        )
+
+    parser = KindleCsvParser()
+    highlights = list(parser.parse(sample_path))
+
+    assert len(highlights) == 1
+    highlight = highlights[0]
+    assert highlight.text == "CSV highlight text"
+    assert highlight.note == "CSV note"
+    assert highlight.location == "200-201"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from highlights.models import Highlight
+from highlights.storage import BookFile, append_highlights_to_file, build_book_filename
+
+
+def make_highlight(**kwargs) -> Highlight:
+    base = {
+        "book_title": "The Example Book",
+        "author": "Jane Doe",
+        "location": "120-122",
+        "text": "This is a highlight.",
+        "note": "Optional note.",
+        "source": "test",
+    }
+    base.update(kwargs)
+    return Highlight(**base)
+
+
+def test_append_highlights_deduplicates(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    book_path = build_book_filename(vault, "Kindle Highlights", "The Example Book")
+    book_file = BookFile(book_path, "The Example Book", "Jane Doe")
+
+    first_highlight = make_highlight()
+    second_highlight = make_highlight(location="200-201", text="Another highlight")
+
+    added, total = append_highlights_to_file(book_file, [first_highlight])
+    assert added == 1
+    assert total == 1
+
+    added_again, total_again = append_highlights_to_file(book_file, [first_highlight, second_highlight])
+    assert added_again == 1
+    assert total_again == 2
+
+    content = book_path.read_text(encoding="utf-8")
+    assert content.count("highlight-id") == 2


### PR DESCRIPTION
## Summary
- add a Python CLI entry point that ingests Kindle clippings/CSV exports and writes Markdown files into an Obsidian vault
- implement parsing, rendering, and storage helpers to normalise highlights, deduplicate via hashes, and support configurable heading templates
- document configuration and usage, supply packaging metadata, and cover critical paths with pytest-based smoke tests

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e25c12544c8332a7c5f8f45326a1e1