### PR TITLE
Allow My Clippings parser to handle highlights without Your token

### DIFF
--- a/src/highlights/parsers.py
+++ b/src/highlights/parsers.py
@@ -22,7 +22,7 @@ class MyClippingsParser(HighlightParser):
 
     SEPARATOR = "=========="
     META_PATTERN = re.compile(
-        r"^-\s*Your\s+(?P<entry_type>Highlight|Note)\s+on\s+"  # entry type
+        r"^-\s*(?:Your\s+)?(?P<entry_type>Highlight|Note)\s+on\s+"  # entry type
         r"(?:(?:Location|Page)\s+(?P<location>[\d\-]+))?.*"  # location (optional)
     )
 

--- a/tests/test_parsers.py
+++ b/tests/test_parsers.py
@@ -7,11 +7,11 @@ from highlights.parsers import KindleCsvParser, MyClippingsParser
 MY_CLIPPINGS_SAMPLE = """The Example Book (Jane Doe)
 - Your Highlight on Location 120-122 | Added on Friday, 1 January 2021 10:00:00
 This is a highlight from the book.
-==========
+========== 
 The Example Book (Jane Doe)
 - Your Note on Location 120 | Added on Friday, 1 January 2021 10:00:00
 This is an attached note.
-==========
+========== 
 """
 
 
@@ -28,6 +28,25 @@ def test_my_clippings_parser_combines_notes(tmp_path: Path) -> None:
     assert highlight.note == "This is an attached note."
     assert highlight.location == "120-122"
     assert highlight.highlight_id  # hash generated
+
+
+def test_my_clippings_parser_handles_highlight_without_your(tmp_path: Path) -> None:
+    sample = """Another Book (Author Name)
+- Highlight on Page 5 | Added on Friday, 1 January 2021 11:00:00
+Highlight text without your token.
+==========
+"""
+
+    sample_path = tmp_path / "My Clippings.txt"
+    sample_path.write_text(sample, encoding="utf-8")
+
+    parser = MyClippingsParser()
+    highlights = list(parser.parse(sample_path))
+
+    assert len(highlights) == 1
+    highlight = highlights[0]
+    assert highlight.text == "Highlight text without your token."
+    assert highlight.location == "5"
 
 
 def test_kindle_csv_parser(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- relax the My Clippings metadata pattern to allow entries without the "Your" prefix
- cover parsing of highlights that start with "- Highlight on Page" in the test suite

## Testing
- python -m pytest

------
https://chatgpt.com/codex/tasks/task_e_68e266a4e1848332b7149b866cc902e9