### PR TITLE
Preserve spaces in sanitised filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ python -m sync_highlights --config config.json
 
 ### Markdown output
 
-Each book gets its own Markdown file (e.g. `Kindle Highlights/The_Example_Book.md`) with front matter containing the title, author and stored highlight hashes. Highlights are rendered as sections:
+Each book gets its own Markdown file (e.g. `Kindle Highlights/My Book Title.md`) with front matter containing the title, author and stored highlight hashes. Highlights are rendered as sections:
 
 ```markdown
 ### Location 120-122

--- a/src/highlights/markdown.py
+++ b/src/highlights/markdown.py
@@ -13,9 +13,8 @@ SAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._\- ]+")
 def sanitise_filename(value: str) -> str:
     """Return a filesystem-safe filename derived from ``value``."""
 
-    safe = SAFE_FILENAME_CHARS.sub(" ", value).strip()
-    safe = re.sub(r"\s+", " ", safe)
-    safe = safe.replace(" ", "_")
+    safe = SAFE_FILENAME_CHARS.sub(" ", value)
+    safe = re.sub(r"\s+", " ", safe).strip()
     return safe or "untitled"
 
 

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -1,0 +1,13 @@
+from highlights.markdown import sanitise_filename
+
+
+def test_sanitise_filename_preserves_spaces():
+    assert sanitise_filename("My Book Title") == "My Book Title"
+
+
+def test_sanitise_filename_collapses_illegal_characters_to_spaces():
+    assert sanitise_filename("My:/\\Book?Title*") == "My Book Title"
+
+
+def test_sanitise_filename_returns_untitled_when_empty():
+    assert sanitise_filename("@#$") == "untitled"

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -35,3 +35,10 @@ def test_append_highlights_deduplicates(tmp_path: Path) -> None:
 
     content = book_path.read_text(encoding="utf-8")
     assert content.count("highlight-id") == 2
+
+
+def test_build_book_filename_preserves_spaces(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    path = build_book_filename(vault, "Kindle Highlights", "My Book Title")
+
+    assert path == vault / "Kindle Highlights" / "My Book Title.md"


### PR DESCRIPTION
## Summary
- update filename sanitisation to keep literal spaces while still removing illegal characters
- document and test the expected space-preserving book filename behaviour
- add regression coverage ensuring book titles with spaces map to Markdown files like "My Book Title.md"

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e29d5f93d08332a067adcfaeffa422