### PR TITLE
Store highlight metadata exclusively in front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,25 @@ python -m sync_highlights --config config.json
 
 ### Markdown output
 
-Each book gets its own Markdown file (e.g. `Kindle Highlights/The_Example_Book.md`) with front matter containing the title, author and stored highlight hashes. Highlights are rendered as sections:
+Each book gets its own Markdown file (e.g. `Kindle Highlights/The_Example_Book.md`) that now stores all data inside the front matter. In addition to title, author and stored highlight hashes, every highlight is persisted as structured metadata so it can be round-tripped without relying on rendered Markdown:
 
 ```markdown
-### Location 120-122
-> The highlighted text
-
-**Note:** Optional note text
-<!-- highlight-id: 123abc... -->
+---
+title: "The Example Book"
+author: "Jane Doe"
+updated: "2024-01-01T12:00:00+00:00"
+highlight_ids:
+  - "123abc..."
+highlights:
+  -
+    id: "123abc..."
+    location: "Location 120-122"
+    text: "The highlighted text"
+    note: "Optional note text"
+---
 ```
 
-The stored `highlight_ids` in front matter are used to avoid adding the same passage multiple times.
+When new highlights are appended the tool only updates this metadata block, ensuring that no additional Markdown body content is written. The stored `highlight_ids` (and the highlight metadata) continue to be used to avoid adding the same passage multiple times.
 
 ### Dry-run and validation
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from highlights.markdown import parse_front_matter
 from highlights.models import Highlight
 from highlights.storage import BookFile, append_highlights_to_file, build_book_filename
 
@@ -34,4 +35,18 @@ def test_append_highlights_deduplicates(tmp_path: Path) -> None:
     assert total_again == 2
 
     content = book_path.read_text(encoding="utf-8")
-    assert content.count("highlight-id") == 2
+    metadata, remainder = parse_front_matter(content)
+    assert remainder == ""
+
+    assert metadata["title"] == "The Example Book"
+    assert metadata["author"] == "Jane Doe"
+    assert metadata["highlight_ids"] == [first_highlight.highlight_id, second_highlight.highlight_id]
+
+    highlights = metadata["highlights"]
+    assert isinstance(highlights, list)
+    assert len(highlights) == 2
+    assert highlights[0]["id"] == first_highlight.highlight_id
+    assert highlights[0]["location"] == first_highlight.location
+    assert highlights[0]["text"] == first_highlight.text
+    assert highlights[0]["note"] == first_highlight.note
+    assert highlights[1]["location"] == second_highlight.location


### PR DESCRIPTION
## Summary
- extend the front matter serializer/parser to support nested data and JSON-compatible scalars
- rewrite the highlight storage routine to persist structured highlight details in metadata only
- refresh documentation and tests to describe and validate the new metadata-only file layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e29d782d8483329bcefc166c287fe7