### PR TITLE
Store highlights as metadata

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -33,8 +33,12 @@ def test_append_highlights_deduplicates(tmp_path: Path) -> None:
     assert added_again == 1
     assert total_again == 2
 
-    content = book_path.read_text(encoding="utf-8")
-    assert content.count("highlight-id") == 2
+    metadata, body = book_file.read()
+    assert isinstance(metadata.get("highlights"), list)
+    assert len(metadata["highlights"]) == 2
+    stored_ids = {entry["highlight_id"] for entry in metadata["highlights"]}
+    assert stored_ids == {first_highlight.highlight_id, second_highlight.highlight_id}
+    assert body.strip() == ""
 
 
 def test_build_book_filename_preserves_spaces(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- serialize highlights into the Markdown front matter instead of appending rendered sections
- extend front matter helpers to handle nested metadata via JSON while remaining backward compatible with older list formats
- update tests to validate highlight metadata persistence and ensure empty document bodies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a21e6c388332abd259b33bf268ca