### PR TITLE
Simplify stored highlight metadata entries

### DIFF
--- a/src/highlights/markdown.py
+++ b/src/highlights/markdown.py
@@ -83,13 +83,16 @@ def parse_front_matter(text: str) -> tuple[dict, str]:
     return metadata, remainder
 
 
+def _format_location_text(location: Optional[str]) -> str:
+    if not location:
+        return "Location unknown"
+    return f"Location {location}"
+
+
 def serialise_highlight(highlight: Highlight) -> Dict[str, Any]:
     return {
-        "highlight_id": highlight.highlight_id,
-        "location": highlight.location,
         "text": highlight.text,
-        "note": highlight.note,
-        "source": highlight.source,
+        "location_text": _format_location_text(highlight.location),
     }
 
 


### PR DESCRIPTION
## Summary
- simplify highlight serialisation so stored entries include only text and a formatted location
- preserve highlight ID tracking while merging new highlight structures when appending to files
- extend storage tests to cover the new schema and missing location handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2a6f99ea88332bcd0df18632cf3b4